### PR TITLE
Allow output to io.Writer and implement teardown

### DIFF
--- a/bind/api.go
+++ b/bind/api.go
@@ -2,6 +2,7 @@
 package bind
 
 import (
+	"io"
 	"time"
 
 	"github.com/go-mix/mix/bind/hardware/null"
@@ -32,10 +33,10 @@ func SetOutputCallback(fn sample.OutNextCallbackFunc) {
 }
 
 // OutputStart requires a known length
-func OutputStart(length time.Duration) {
+func OutputStart(length time.Duration, out io.Writer) {
 	switch useOutput {
 	case opt.OutputWAV:
-		wav.OutputStart(length)
+		wav.OutputStart(length, out)
 	case opt.OutputNull:
 		// do nothing
 	}

--- a/bind/wav/writer.go
+++ b/bind/wav/writer.go
@@ -4,22 +4,21 @@ package wav
 import (
 	"encoding/binary"
 	"io"
-	"syscall"
 
 	riff "github.com/youpy/go-riff"
 
+	"time"
+
 	"github.com/go-mix/mix/bind/sample"
 	"github.com/go-mix/mix/bind/spec"
-	"os"
-	"time"
 )
 
 func ConfigureOutput(s spec.AudioSpec) {
 	outputSpec = &s
 }
 
-func OutputStart(length time.Duration) {
-	writer = NewWriter(stdout, FormatFromSpec(outputSpec), length)
+func OutputStart(length time.Duration, out io.Writer) {
+	writer = NewWriter(out, FormatFromSpec(outputSpec), length)
 }
 
 func TeardownOutput() {
@@ -57,7 +56,6 @@ func OutputNext(numSamples spec.Tz) (err error) {
 //
 
 var (
-	stdout     = os.NewFile(uintptr(syscall.Stdout), "/dev/stdout")
 	writer     *Writer
 	outputSpec *spec.AudioSpec
 )

--- a/demo/demo.go
+++ b/demo/demo.go
@@ -96,8 +96,9 @@ func main() {
 
 	//
 	if bind.IsDirectOutput() {
+		out := os.Stdout
 		mix.Debug(true)
-		mix.OutputStart(t)
+		mix.OutputStart(t, out)
 		for p := time.Duration(0); p <= t; p += t / 4 {
 			mix.OutputContinueTo(p)
 		}

--- a/lib/mix/mix.go
+++ b/lib/mix/mix.go
@@ -2,6 +2,7 @@
 package mix
 
 import (
+	"io"
 	"math"
 	"time"
 
@@ -54,8 +55,8 @@ func Spec() *spec.AudioSpec {
 
 // Teardown everything and release all memory.
 func Teardown() {
-  ClearAllFires()
-  outputToDur = time.Duration(0)
+	ClearAllFires()
+	outputToDur = time.Duration(0)
 }
 
 // SetFire to represent a single audio source playing at a specific time in the future (in time.Duration from play start), with sustain time.Duration, volume from 0 to 1, and pan from -1 to +1
@@ -116,8 +117,8 @@ func GetCycleDurationTz() spec.Tz {
 }
 
 // OutputStart requires a known length
-func OutputStart(length time.Duration) {
-	bind.OutputStart(length)
+func OutputStart(length time.Duration, out io.Writer) {
+	bind.OutputStart(length, out)
 }
 
 // OutputContinueTo to  mix and output as []byte via stdout, up to a specified duration-since-start

--- a/lib/mix/mix.go
+++ b/lib/mix/mix.go
@@ -57,6 +57,8 @@ func Spec() *spec.AudioSpec {
 func Teardown() {
 	ClearAllFires()
 	outputToDur = time.Duration(0)
+	nextCycleTz = 0
+	nowTz = 0
 }
 
 // SetFire to represent a single audio source playing at a specific time in the future (in time.Duration from play start), with sustain time.Duration, volume from 0 to 1, and pan from -1 to +1

--- a/lib/mix/mix.go
+++ b/lib/mix/mix.go
@@ -54,6 +54,8 @@ func Spec() *spec.AudioSpec {
 
 // Teardown everything and release all memory.
 func Teardown() {
+  ClearAllFires()
+  outputToDur = time.Duration(0)
 }
 
 // SetFire to represent a single audio source playing at a specific time in the future (in time.Duration from play start), with sustain time.Duration, volume from 0 to 1, and pan from -1 to +1

--- a/mix.go
+++ b/mix.go
@@ -148,6 +148,7 @@
 package mix
 
 import (
+	"io"
 	"time"
 
 	"github.com/go-mix/mix/bind"
@@ -231,8 +232,8 @@ func GetNowAt() time.Duration {
 }
 
 // OutputStart requires a known length
-func OutputStart(length time.Duration) {
-	mix.OutputStart(length)
+func OutputStart(length time.Duration, out io.Writer) {
+	mix.OutputStart(length, out)
 }
 
 // OutputContinueTo output as []byte via stdout, up to a specified duration-since-start


### PR DESCRIPTION
Allows specifying the location to write data to (write to any io.Writer).

Implements Teardown in mix to reset fires and outputToDur to allow subsequent outputs to work.