### PR TITLE
Add go-sox loader interface

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: go
+dist: trusty
 
 go:
   - 1.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ go:
 install:
   - # WAV loading
   - go get github.com/youpy/go-riff
+  - # SOX bindings
+  - sudo apt-get install -y libsox-dev
+  - go get github.com/krig/go-sox
   - # Testing
   - go get github.com/stretchr/testify/assert
   - go get github.com/stretchr/testify/mock

--- a/bind/api.go
+++ b/bind/api.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-mix/mix/bind/hardware/null"
 	"github.com/go-mix/mix/bind/opt"
 	"github.com/go-mix/mix/bind/sample"
+	"github.com/go-mix/mix/bind/sox"
 	"github.com/go-mix/mix/bind/spec"
 	"github.com/go-mix/mix/bind/wav"
 )
@@ -57,6 +58,8 @@ func LoadWAV(file string) ([]sample.Sample, *spec.AudioSpec) {
 	switch useLoader {
 	case opt.InputWAV:
 		return wav.Load(file)
+	case opt.InputSOX:
+		return sox.Load(file)
 	default:
 		return make([]sample.Sample, 0), &spec.AudioSpec{}
 	}
@@ -82,6 +85,8 @@ func UseLoaderString(loader string) {
 	switch loader {
 	case string(opt.InputWAV):
 		useLoader = opt.InputWAV
+	case string(opt.InputSOX):
+		useLoader = opt.InputSOX
 	default:
 		panic("No such Loader: " + loader)
 	}

--- a/bind/opt/option.go
+++ b/bind/opt/option.go
@@ -5,7 +5,10 @@ package opt
 type Input string
 
 // OptLoadWav to use Go-Native WAV file I/O
-const InputWAV Input = "wav"
+const (
+	InputWAV Input = "wav"
+	InputSOX Input = "sox"
+)
 
 // OptOutput represents an audio output option
 type Output string

--- a/bind/sox/sox.go
+++ b/bind/sox/sox.go
@@ -1,0 +1,41 @@
+// Package sox is for file I/O via go-sox package
+package sox
+
+import (
+	"github.com/go-mix/mix/bind/sample"
+	"github.com/go-mix/mix/bind/spec"
+	sox "github.com/krig/go-sox"
+)
+
+const ChunkSize = 2048
+
+// Load sound file into memory
+func Load(path string) (out []sample.Sample, specs *spec.AudioSpec) {
+	file := sox.OpenRead(path)
+	if file == nil {
+		panic("Sox can't open file: " + path)
+	}
+	defer file.Release()
+	info := file.Signal()
+	specs = &spec.AudioSpec{
+		Freq:     info.Rate(),
+		Format:   spec.AudioS32,
+		Channels: int(info.Channels()),
+	}
+	buffer := make([]sox.Sample, ChunkSize*specs.Channels)
+	for {
+		size := file.Read(buffer, uint(len(buffer)))
+		if size == 0 || size == sox.EOF {
+			break
+		}
+		outBuffer := make([]sample.Value, size)
+		for offset := 0; offset < int(size); offset += specs.Channels {
+			values := outBuffer[offset : offset+specs.Channels]
+			for c := 0; c < specs.Channels; c++ {
+				values[c] = sample.Value(sox.SampleToFloat64(buffer[offset+c]))
+			}
+			out = append(out, sample.New(values))
+		}
+	}
+	return
+}

--- a/demo/demo.go
+++ b/demo/demo.go
@@ -17,7 +17,7 @@ import (
 )
 
 var (
-	out         string
+	loader, out string
 	profileMode string
 	sampleHz    = float64(48000)
 	specs       = spec.AudioSpec{
@@ -60,6 +60,7 @@ func main() {
 	// command-line arguments
 	flag.StringVar(&out, "out", "null", "playback binding [null] _OR_ [wav] for direct stdout (e.g. >file or |aplay)")
 	flag.StringVar(&profileMode, "profile", "", "enable profiling [cpu, mem, block]")
+	flag.StringVar(&loader, "loader", "wav", "input loading interface [wav, sox]")
 	flag.Parse()
 
 	// CPU/Memory/Block profiling
@@ -79,6 +80,7 @@ func main() {
 
 	// configure mix
 	bind.UseOutputString(out)
+	bind.UseLoaderString(loader)
 	defer mix.Teardown()
 	mix.Configure(specs)
 	mix.SetSoundsPath(prefix)


### PR DESCRIPTION
Use github.com/krig/go-sox package to use formats supported by sox for input. Unfortunately it requires linking to libsox via cgo, which is quite heavy dependency. 